### PR TITLE
GCP Server Docker Container 배포 시 오디오 드라이버 오류

### DIFF
--- a/app/pages/help_my_exam_my_helper.py
+++ b/app/pages/help_my_exam_my_helper.py
@@ -132,3 +132,4 @@ with col2:
     if st.button("듣기"):
         assistive_features.tts_service(st.session_state.ai_response)
 
+

--- a/modules/assistive_features.py
+++ b/modules/assistive_features.py
@@ -26,9 +26,9 @@ class AssistiveFeatures:
             speed=1.1,
         )
 
+
         response.stream_to_file(speech_file_path)
-        pygame.mixer.music.load(speech_file_path)
-        pygame.mixer.music.play()
+        playsound(speech_file_path)
 
     def stt_service(self):
         with sr.Microphone() as source:


### PR DESCRIPTION
GCP 환경에서 Docker 컨테이너를 빌드 및 실행하여 애플리케이션을 웹 서비스로 배포하는 중 사운드 드라이버 관련 오류가 떴습니다.
보통 클라이언트가 오디오 재생을 처리해야하지만 현재 프론트를 할 수 없는 상황이라 묻어두기로 했습니다. 로컬에서는 잘 작동하지만
GCP같은 오디오 드라이버나 재생장치가 없는 Server에서는 클라이언트가 처리해줘야 한다는 것을 알았고 Streamlit으로 너무나 명확한 한계가 있었습니다.